### PR TITLE
remove params in models/layers/z_buffer_layers.py

### DIFF
--- a/models/layers/z_buffer_layers.py
+++ b/models/layers/z_buffer_layers.py
@@ -75,8 +75,6 @@ class RasterizePointsXYsBlending(nn.Module):
         # src = torch.cat((src, self.default_feature.repeat(bs, 1, 1)), 2)
 
         radius = float(self.radius) / float(image_size) * 2.0
-        params = compositing.CompositeParams(radius=radius)
-
 
         pts3D = Pointclouds(points=pts3D, features=src.permute(0,2,1))
         points_idx, _, dist = rasterize_points(
@@ -102,21 +100,18 @@ class RasterizePointsXYsBlending(nn.Module):
                 points_idx.permute(0, 3, 1, 2).long(),
                 alphas,
                 pts3D.features_packed().permute(1,0),
-                params,
             )
         elif self.opts.accumulation == 'wsum':
             transformed_src_alphas = compositing.weighted_sum(
                 points_idx.permute(0, 3, 1, 2).long(),
                 alphas,
                 pts3D.features_packed().permute(1,0),
-                params,
             )
         elif self.opts.accumulation == 'wsumnorm':
             transformed_src_alphas = compositing.weighted_sum_norm(
                 points_idx.permute(0, 3, 1, 2).long(),
                 alphas,
                 pts3D.features_packed().permute(1,0),
-                params,
             )
 
         return transformed_src_alphas


### PR DESCRIPTION
As it is mentioned in [issues/18](https://github.com/facebookresearch/synsin/issues/18), this removes the unused params to align with pytorch v0.2.0.

However, I did observe slight different between the figures generated from [Simple Demo.ipynb](https://github.com/facebookresearch/synsin/blob/master/demos/Simple%20Demo.ipynb) after the change. 

Before (the default cached figure in the origin .ipynb)
![default](https://user-images.githubusercontent.com/32551664/87707241-a86bb500-c755-11ea-9f7b-30fd9b3d13ea.png)
After the change
![after](https://user-images.githubusercontent.com/32551664/87707257-af92c300-c755-11ea-9061-bb4dfa0f2d7f.png)
Difference in the curtain area after the sofa.

You can investigate whether anything might be actually affected by the change.

Thanks