### PR TITLE
Memory leak in custom batch-norm

### DIFF
--- a/models/layers/normalization.py
+++ b/models/layers/normalization.py
@@ -137,19 +137,20 @@ class bn(nn.Module):
                 x, gain, bias, return_mean_var=True, eps=self.eps
             )
             # If accumulating standing stats, increment them
-            if self.accumulate_standing:
-                self.stored_mean[:] = self.stored_mean + mean.data
-                self.stored_var[:] = self.stored_var + var.data
-                self.accumulation_counter += 1.0
-            # If not accumulating standing stats, take running averages
-            else:
-                self.stored_mean[:] = (
-                    self.stored_mean * (1 - self.momentum)
-                    + mean * self.momentum
-                )
-                self.stored_var[:] = (
-                    self.stored_var * (1 - self.momentum) + var * self.momentum
-                )
+            with torch.no_grad():
+                if self.accumulate_standing:
+                    self.stored_mean[:] = self.stored_mean + mean.data
+                    self.stored_var[:] = self.stored_var + var.data
+                    self.accumulation_counter += 1.0
+                # If not accumulating standing stats, take running averages
+                else:
+                    self.stored_mean[:] = (
+                        self.stored_mean * (1 - self.momentum)
+                        + mean * self.momentum
+                    )
+                    self.stored_var[:] = (
+                        self.stored_var * (1 - self.momentum) + var * self.momentum
+                    )
             return out
         # If not in training mode, use the stored statistics
         else:


### PR DESCRIPTION
Using the `ResNetEncoder` and `ResNetDecoder` models results in a pretty hefty (~7MB/s) memory leak on CPU memory, which ultimately results in training crashing after a couple days.

I traced it down to a few lines in the custom batch-norm. The variables `self.stored_mean`, `self.stored_var` seem to only be used during inference, but are not protected from computing gradients, and thus are extending the computation graph on each call to `bn.forward()`.

An old issue on the main PyTorch repo seems to validate these findings:
https://github.com/pytorch/pytorch/issues/20275

I've tested with this change, and the memory usage remains constant. 