### PR TITLE
Handled `identity` variable referenced before assignment when no cuda available

### DIFF
--- a/models/z_buffermodel.py
+++ b/models/z_buffermodel.py
@@ -154,6 +154,10 @@ class ZbufferModelPts(nn.Module):
             identity = (
                 torch.eye(4).unsqueeze(0).repeat(input_img.size(0), 1, 1).cuda()
             )
+        else:
+            identity = (
+                torch.eye(4).unsqueeze(0).repeat(input_img.size(0), 1, 1)
+            )
 
         fs = self.encoder(input_img)
         regressed_pts = (


### PR DESCRIPTION
`identity` is defined in the `if torch.cuda.is_available()` block.
This PR defines it in an `else` block for non-cuda systems.